### PR TITLE
remove ATen inplace add from ONNX graph

### DIFF
--- a/openpifpaf/export_onnx.py
+++ b/openpifpaf/export_onnx.py
@@ -67,6 +67,7 @@ def apply(model, outfile, verbose=True):
     torch.onnx.export(
         model, dummy_input, outfile, verbose=verbose,
         input_names=input_names, output_names=output_names,
+        keep_initializers_as_inputs=True,
         # opset_version=10,
         # do_constant_folding=True,
         # dynamic_axes={  # TODO: gives warnings

--- a/openpifpaf/export_onnx.py
+++ b/openpifpaf/export_onnx.py
@@ -69,7 +69,8 @@ def apply(model, outfile, verbose=True):
         input_names=input_names, output_names=output_names,
         keep_initializers_as_inputs=True,
         # opset_version=10,
-        # do_constant_folding=True,
+        do_constant_folding=True,
+        export_params=True,
         # dynamic_axes={  # TODO: gives warnings
         #     'input_batch': {0: 'batch', 2: 'height', 3: 'width'},
         #     'pif_c': {0: 'batch', 2: 'fheight', 3: 'fwidth'},
@@ -122,7 +123,8 @@ def simplify(infile, outfile=None):
         infile = infile.replace('.onnx', '.unsimplified.onnx')
         shutil.copyfile(outfile, infile)
 
-    simplified_model = onnxsim.simplify(infile, check_n=0, perform_optimization=False)
+    simplified_model, check_ok = onnxsim.simplify(infile, check_n=3, perform_optimization=False)
+    assert check_ok
     onnx.save(simplified_model, outfile)
 
 

--- a/openpifpaf/network/heads.py
+++ b/openpifpaf/network/heads.py
@@ -78,10 +78,10 @@ class CifCafCollector(torch.nn.Module):
         # add index
         index_field = index_field_torch(cif_head.shape[-2:], device=cif_head.device)
         if cif_head is not None:
-            cif_head[:, :, 1:3] += index_field
+            cif_head[:, :, 1:3].add_(index_field)
         if caf_head is not None:
-            caf_head[:, :, 1:3] += index_field
-            caf_head[:, :, 3:5] += index_field
+            caf_head[:, :, 1:3].add_(index_field)
+            caf_head[:, :, 3:5].add_(index_field)
             # rearrange caf_fields
             caf_head = caf_head[:, :, (0, 1, 2, 5, 7, 3, 4, 6, 8)]
 

--- a/setup.py
+++ b/setup.py
@@ -82,12 +82,12 @@ setup(
         ],
         'onnx': [
             'onnx',
-            'onnx-simplifier',
+            'onnx-simplifier>=0.2.9',
         ],
         'test': [
             'nbval',
             'onnx',
-            'onnx-simplifier',
+            'onnx-simplifier>=0.2.9',
             'pylint',
             'pytest',
             'opencv-python',

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         'test': [
             'nbval',
             'onnx',
+            'onnx-simplifier',
             'pylint',
             'pytest',
             'opencv-python',

--- a/tests/test_onnx_export.py
+++ b/tests/test_onnx_export.py
@@ -15,12 +15,10 @@ def test_onnx_exportable(tmpdir):
     )
     openpifpaf.export_onnx.apply(model, outfile, verbose=False)
     assert os.path.exists(outfile)
-
-    openpifpaf.export_onnx.simplify(outfile)
-    assert os.path.exists(outfile)  # TODO better check
-
-    openpifpaf.export_onnx.polish(outfile)
-    assert os.path.exists(outfile)  # TODO better check
-
     openpifpaf.export_onnx.check(outfile)
-    assert os.path.exists(outfile)  # TODO better check
+
+    openpifpaf.export_onnx.polish(outfile, outfile + '.polished')
+    assert os.path.exists(outfile + '.polished')
+
+    openpifpaf.export_onnx.simplify(outfile, outfile + '.simplified')
+    assert os.path.exists(outfile + '.simplified')

--- a/tests/test_onnx_export.py
+++ b/tests/test_onnx_export.py
@@ -16,7 +16,11 @@ def test_onnx_exportable(tmpdir):
     openpifpaf.export_onnx.apply(model, outfile, verbose=False)
     assert os.path.exists(outfile)
 
-    # The following two onnx operations are currently broken.
-    # Probably due to: https://github.com/onnx/onnx/issues/2417
-    # openpifpaf.export_onnx.polish(outfile)
-    # openpifpaf.export_onnx.check(outfile)
+    openpifpaf.export_onnx.simplify(outfile)
+    assert os.path.exists(outfile)  # TODO better check
+
+    openpifpaf.export_onnx.polish(outfile)
+    assert os.path.exists(outfile)  # TODO better check
+
+    openpifpaf.export_onnx.check(outfile)
+    assert os.path.exists(outfile)  # TODO better check

--- a/tests/test_onnx_export.py
+++ b/tests/test_onnx_export.py
@@ -1,9 +1,12 @@
 import os
+import pytest
+import torch
 
 import openpifpaf
 import openpifpaf.export_onnx
 
 
+@pytest.mark.skipif(not torch.__version__.startswith('1.5'), reason='only PyTorch 1.5')
 def test_onnx_exportable(tmpdir):
     outfile = str(tmpdir.join('openpifpaf-shufflenetv2k16w.onnx'))
     assert not os.path.exists(outfile)


### PR DESCRIPTION
In place `+=` is not well supported. Switch to `.add_()`.

In export_onnx, use now `keep_initializers_as_inputs=True`.

Fixes #238 