### PR TITLE
fix Focal loss

### DIFF
--- a/openpifpaf/logs.py
+++ b/openpifpaf/logs.py
@@ -285,7 +285,7 @@ class Plots(object):
 
         ax.set_xlabel('epoch')
         ax.set_ylabel(format(field_name))
-        ax.set_ylim(3e-3, 3.0)
+        # ax.set_ylim(3e-3, 3.0)
         if min(y) > -0.1:
             ax.set_yscale('log', nonposy='clip')
         ax.grid(linestyle='dotted')

--- a/openpifpaf/network/losses.py
+++ b/openpifpaf/network/losses.py
@@ -8,25 +8,6 @@ from . import heads
 LOG = logging.getLogger(__name__)
 
 
-class BceTuned(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.log_sigma = torch.nn.Parameter(torch.zeros((1,), dtype=torch.float64))
-
-    def forward(self, x, t):  # pylint: disable=arguments-differ
-        bce = torch.nn.functional.binary_cross_entropy_with_logits(
-            x,
-            t,
-            reduction='none',
-        )
-
-        # constrain range of logsigma
-        logsigma_constr = 3.0 * torch.tanh(self.log_sigma / 3.0)
-
-        # ln(sqrt(2pi)) = 0.919
-        return logsigma_constr + bce * 0.5 * torch.exp(-2.0 * logsigma_constr)
-
-
 class Bce(torch.nn.Module):
     def forward(self, x, t):  # pylint: disable=arguments-differ
         # print(torch.min(x).item(), torch.max(x).item())
@@ -88,8 +69,7 @@ def l1_loss(x1, x2, _, t1, t2, weight=None):
     Loss for a single two-dimensional vector (x1, x2)
     true (t1, t2) vector.
     """
-    # losses = torch.sqrt((x1 - t1)**2 + (x2 - t2)**2)
-    losses = (torch.stack((x1, x2)) - torch.stack((t1, t2))).norm(dim=0)
+    losses = torch.sqrt((x1 - t1)**2 + (x2 - t2)**2)
     if weight is not None:
         losses = losses * weight
     return losses

--- a/openpifpaf/network/losses.py
+++ b/openpifpaf/network/losses.py
@@ -162,11 +162,11 @@ class MultiHeadLoss(torch.nn.Module):
         return total_loss, flat_head_losses
 
 
-class MultiHeadLossAutoTune(torch.nn.Module):
+class MultiHeadLossAutoTuneKendall(torch.nn.Module):
     task_sparsity_weight = 0.0
 
     def __init__(self, losses, lambdas, *, sparse_task_parameters=None):
-        """Auto-tuning multi-head less.
+        """Auto-tuning multi-head loss.
 
         Uses idea from "Multi-Task Learning Using Uncertainty to Weigh Losses
         for Scene Geometry and Semantics" by Kendall, Gal and Cipolla.
@@ -218,6 +218,87 @@ class MultiHeadLossAutoTune(torch.nn.Module):
                     for lam, log_sigma, l in zip(self.lambdas, self.log_sigmas, flat_head_losses)
                     if l is not None]
         total_loss = sum(loss_values) + sum(auto_reg) if loss_values else None
+
+        if self.task_sparsity_weight and self.sparse_task_parameters is not None:
+            head_sparsity_loss = sum(
+                # torch.norm(param, p=1)
+                param.abs().max(dim=1)[0].clamp(min=1e-6).sum()
+                for param in self.sparse_task_parameters
+            )
+            LOG.debug('l1 head sparsity loss = %f (total = %f)', head_sparsity_loss, total_loss)
+            total_loss = total_loss + self.task_sparsity_weight * head_sparsity_loss
+
+        return total_loss, flat_head_losses
+
+
+class MultiHeadLossAutoTuneVariance(torch.nn.Module):
+    task_sparsity_weight = 0.0
+
+    def __init__(self, losses, lambdas, *, sparse_task_parameters=None):
+        """Auto-tuning multi-head loss based on loss-variance.
+
+        In the common setting, use lambdas of zero and one to deactivate and
+        activate the tasks you want to train. Less common, if you have
+        secondary tasks, you can reduce their importance by choosing a
+        lambda value between zero and one.
+        """
+        super().__init__()
+
+        if not lambdas:
+            lambdas = [1.0 for l in losses for _ in l.field_names]
+        assert all(lam >= 0.0 for lam in lambdas)
+
+        self.losses = torch.nn.ModuleList(losses)
+        self.lambdas = lambdas
+        self.sparse_task_parameters = sparse_task_parameters
+
+        self.epsilons = torch.ones((len(lambdas),), dtype=torch.float64)
+        self.buffer = torch.full((len(lambdas), 50), float('nan'), dtype=torch.float64)
+        self.buffer_index = -1
+
+        self.field_names = [n for l in self.losses for n in l.field_names]
+        LOG.info('multihead loss with autotune: %s', self.field_names)
+        assert len(self.field_names) == len(self.lambdas)
+        assert len(self.field_names) == len(self.epsilons)
+
+    def batch_meta(self):
+        return {'mtl_sigmas': [round(float(s), 3) for s in self.epsilons]}
+
+    def forward(self, *args):
+        head_fields, head_targets = args
+        LOG.debug('losses = %d, fields = %d, targets = %d',
+                  len(self.losses), len(head_fields), len(head_targets))
+        assert len(self.losses) == len(head_fields)
+        assert len(self.losses) <= len(head_targets)
+        flat_head_losses = [ll
+                            for l, f, t in zip(self.losses, head_fields, head_targets)
+                            for ll in l(f, t)]
+
+        self.buffer_index = (self.buffer_index + 1) % self.buffer.shape[1]
+        for i, ll in enumerate(flat_head_losses):
+            if not hasattr(ll, 'data'):  # e.g. when ll is None
+                continue
+            self.buffer[i, self.buffer_index] = ll.data
+        self.epsilons = torch.sqrt(
+            torch.mean(self.buffer**2, dim=1)
+            - torch.sum(self.buffer, dim=1)**2 / self.buffer.shape[1]**2
+        )
+        self.epsilons[torch.isnan(self.epsilons)] = 10.0
+        self.epsilons = self.epsilons.clamp(0.01, 100.0)
+
+        # normalize sum 1/eps to the number of sub-losses
+        LOG.debug('eps before norm: %s', self.epsilons)
+        self.epsilons = self.epsilons * torch.sum(1.0 / self.epsilons) / self.epsilons.shape[0]
+        LOG.debug('eps after norm: %s', self.epsilons)
+
+        assert len(self.lambdas) == len(flat_head_losses)
+        assert len(self.epsilons) == len(flat_head_losses)
+        loss_values = [
+            lam * l / eps
+            for lam, eps, l in zip(self.lambdas, self.epsilons, flat_head_losses)
+            if l is not None
+        ]
+        total_loss = sum(loss_values) if loss_values else None
 
         if self.task_sparsity_weight and self.sparse_task_parameters is not None:
             head_sparsity_loss = sum(
@@ -392,9 +473,12 @@ def cli(parser):
                        help='when > 0.0, use focal loss with the given gamma')
     group.add_argument('--margin-loss', default=False, action='store_true',
                        help='[experimental]')
-    group.add_argument('--auto-tune-mtl', default=False, action='store_true',
+    group.add_argument('--auto-tune-mtl-kendall', default=False, action='store_true',
                        help='use Kendall\'s prescription for adjusting the multitask weight')
-    assert MultiHeadLoss.task_sparsity_weight == MultiHeadLossAutoTune.task_sparsity_weight
+    group.add_argument('--auto-tune-mtl', default=False, action='store_true',
+                       help='use Variance prescription for adjusting the multitask weight')
+    assert MultiHeadLoss.task_sparsity_weight == MultiHeadLossAutoTuneKendall.task_sparsity_weight
+    assert MultiHeadLoss.task_sparsity_weight == MultiHeadLossAutoTuneVariance.task_sparsity_weight
     group.add_argument('--task-sparsity-weight',
                        default=MultiHeadLoss.task_sparsity_weight, type=float,
                        help='[experimental]')
@@ -408,7 +492,8 @@ def configure(args):
 
     # MultiHeadLoss
     MultiHeadLoss.task_sparsity_weight = args.task_sparsity_weight
-    MultiHeadLossAutoTune.task_sparsity_weight = args.task_sparsity_weight
+    MultiHeadLossAutoTuneKendall.task_sparsity_weight = args.task_sparsity_weight
+    MultiHeadLossAutoTuneVariance.task_sparsity_weight = args.task_sparsity_weight
 
     # SmoothL1
     SmoothL1Loss.r_smooth = args.r_smooth
@@ -421,13 +506,14 @@ def factory_from_args(args, head_nets):
         reg_loss_name=args.regression_loss,
         device=args.device,
         auto_tune_mtl=args.auto_tune_mtl,
+        auto_tune_mtl_kendall=args.auto_tune_mtl_kendall,
     )
 
 
 # pylint: disable=too-many-branches
 def factory(head_nets, lambdas, *,
             reg_loss_name=None, device=None,
-            auto_tune_mtl=False):
+            auto_tune_mtl=False, auto_tune_mtl_kendall=False):
     if isinstance(head_nets[0], (list, tuple)):
         return [factory(hn, lam,
                         reg_loss_name=reg_loss_name,
@@ -459,8 +545,11 @@ def factory(head_nets, lambdas, *,
 
     losses = [CompositeLoss(head_net, reg_loss) for head_net in head_nets]
     if auto_tune_mtl:
-        loss = MultiHeadLossAutoTune(losses, lambdas,
-                                     sparse_task_parameters=sparse_task_parameters)
+        loss = MultiHeadLossAutoTuneVariance(losses, lambdas,
+                                             sparse_task_parameters=sparse_task_parameters)
+    elif auto_tune_mtl_kendall:
+        loss = MultiHeadLossAutoTuneKendall(losses, lambdas,
+                                            sparse_task_parameters=sparse_task_parameters)
     else:
         loss = MultiHeadLoss(losses, lambdas)
 

--- a/openpifpaf/network/losses.py
+++ b/openpifpaf/network/losses.py
@@ -400,7 +400,7 @@ class CompositeLoss(torch.nn.Module):
         LOG.debug('%s: n_vectors = %d, n_scales = %d, margin = %s',
                   head_net.meta.name, self.n_vectors, self.n_scales, self.margin)
 
-        self.confidence_loss = Bce()  # BceTuned()
+        self.confidence_loss = Bce()
         self.regression_loss = regression_loss or laplace_loss
         self.scale_losses = torch.nn.ModuleList([Log1pL1Tuned() for _ in range(self.n_scales)])
         self.field_names = (

--- a/openpifpaf/network/losses.py
+++ b/openpifpaf/network/losses.py
@@ -253,7 +253,10 @@ class MultiHeadLossAutoTuneVariance(torch.nn.Module):
         self.sparse_task_parameters = sparse_task_parameters
 
         self.epsilons = torch.ones((len(lambdas),), dtype=torch.float64)
-        self.buffer = torch.full((len(lambdas), 50), float('nan'), dtype=torch.float64)
+        # choose a prime number for the buffer length:
+        # for multiple tasks, prevents that always the same buffer_index is
+        # skipped which would mean that some nan values will remain forever
+        self.buffer = torch.full((len(lambdas), 53), float('nan'), dtype=torch.float64)
         self.buffer_index = -1
 
         self.field_names = [n for l in self.losses for n in l.field_names]

--- a/openpifpaf/network/trainer.py
+++ b/openpifpaf/network/trainer.py
@@ -112,6 +112,14 @@ class Trainer(object):
         if loss is not None:
             with torch.autograd.profiler.record_function('backward'):
                 loss.backward()
+        # max_norm = 0.01 / self.lr()
+        # total_norm = torch.nn.utils.clip_grad_norm_(
+        #     self.model.parameters(), max_norm, norm_type=float('inf'))
+        # print('total norm before clip: {}, max norm: {}'.format(total_norm, max_norm))
+        # for n, p in self.model.named_parameters():
+        #     max_grad = torch.max(p.grad.abs())
+        #     if max_grad > 10.0:
+        #         print('LARGE GRAD', n, max_grad, torch.min(p).item(), torch.max(p).item())
         if apply_gradients:
             with torch.autograd.profiler.record_function('step'):
                 self.optimizer.step()

--- a/openpifpaf/train.py
+++ b/openpifpaf/train.py
@@ -65,6 +65,8 @@ def cli():
                         help='update batch norm running statistics')
     parser.add_argument('--ema', default=1e-2, type=float,
                         help='ema decay constant')
+    parser.add_argument('--log-interval', default=10, type=int,
+                        help='log loss every n steps')
     parser.add_argument('--disable-cuda', action='store_true',
                         help='disable CUDA')
 
@@ -104,7 +106,9 @@ def main():
     net_cpu.process_heads = None
     if args.output is None:
         args.output = default_output_file(args, net_cpu)
-    logs.configure(args)
+
+    log_level = logs.configure(args)
+    LOG.setLevel(log_level)
     if args.log_stats:
         logging.getLogger('openpifpaf.stats').setLevel(logging.DEBUG)
 
@@ -127,6 +131,7 @@ def main():
         fix_batch_norm=not args.update_batchnorm_runningstatistics,
         stride_apply=args.stride_apply,
         ema_decay=args.ema,
+        log_interval=args.log_interval,
         train_profile=args.profile,
         model_meta_data={
             'args': vars(args),


### PR DESCRIPTION
* previously, gradients did not propagate through Focal loss term leading to instabilities late in the training
* new gradient protection when overtraining: prevent regression and scale loss from blowing up even in overtraining scenarios
* new tune mechanism: they are not recommended to use. The regression and scale losses themselves come with "tune" terms.
* all loss scaling factors are removed

CC: @george-adaimi 