### PR TITLE
reintroduce crowd margin

### DIFF
--- a/openpifpaf/annotation.py
+++ b/openpifpaf/annotation.py
@@ -16,6 +16,7 @@ class Annotation:
         self.data = np.zeros((len(keypoints), 3), dtype=np.float32)
         self.joint_scales = np.zeros((len(keypoints),), dtype=np.float32)
         self.fixed_score = NOTSET
+        self.fixed_bbox = NOTSET
         self.decoding_order = []
         self.frontier_order = []
 
@@ -31,13 +32,14 @@ class Annotation:
         self.data[joint_i] = xyv
         return self
 
-    def set(self, data, joint_scales=None, *, fixed_score=NOTSET):
+    def set(self, data, joint_scales=None, *, fixed_score=NOTSET, fixed_bbox=NOTSET):
         self.data = data
         if joint_scales is not None:
             self.joint_scales = joint_scales
         else:
             self.joint_scales[:] = 0.0
         self.fixed_score = fixed_score
+        self.fixed_bbox = fixed_bbox
         return self
 
     def rescale(self, scale_factor):
@@ -104,6 +106,8 @@ class Annotation:
         return data
 
     def bbox(self):
+        if self.fixed_bbox != NOTSET:
+            return self.fixed_bbox
         return self.bbox_from_keypoints(self.data, self.joint_scales)
 
     @staticmethod

--- a/openpifpaf/encoder/caf.py
+++ b/openpifpaf/encoder/caf.py
@@ -59,7 +59,8 @@ class CafGenerator:
         width_height_original = image.shape[2:0:-1]
 
         keypoint_sets = self.config.rescaler.keypoint_sets(anns)
-        bg_mask = self.config.rescaler.bg_mask(anns, width_height_original)
+        bg_mask = self.config.rescaler.bg_mask(anns, width_height_original,
+                                               crowd_margin=(self.config.min_size - 1) / 2)
         valid_area = self.config.rescaler.valid_area(meta)
         LOG.debug('valid area: %s', valid_area)
 

--- a/openpifpaf/encoder/cif.py
+++ b/openpifpaf/encoder/cif.py
@@ -42,7 +42,8 @@ class CifGenerator(object):
         width_height_original = image.shape[2:0:-1]
 
         keypoint_sets = self.config.rescaler.keypoint_sets(anns)
-        bg_mask = self.config.rescaler.bg_mask(anns, width_height_original)
+        bg_mask = self.config.rescaler.bg_mask(anns, width_height_original,
+                                               crowd_margin=(self.config.side_length - 1) / 2)
         valid_area = self.config.rescaler.valid_area(meta)
         LOG.debug('valid area: %s, pif side length = %d', valid_area, self.config.side_length)
 
@@ -52,7 +53,7 @@ class CifGenerator(object):
         fields = self.fields(valid_area)
 
         self.config.visualizer.processed_image(image)
-        self.config.visualizer.targets(fields, keypoint_sets=keypoint_sets)
+        self.config.visualizer.targets(fields, annotation_dicts=anns)
 
         return fields
 

--- a/openpifpaf/encoder/cifdet.py
+++ b/openpifpaf/encoder/cifdet.py
@@ -42,7 +42,8 @@ class CifDetGenerator(object):
         width_height_original = image.shape[2:0:-1]
 
         detections = self.config.rescaler.detections(anns)
-        bg_mask = self.config.rescaler.bg_mask(anns, width_height_original)
+        bg_mask = self.config.rescaler.bg_mask(anns, width_height_original,
+                                               crowd_margin=(self.config.side_length - 1) / 2)
         valid_area = self.config.rescaler.valid_area(meta)
         LOG.debug('valid area: %s, pif side length = %d', valid_area, self.config.side_length)
 

--- a/openpifpaf/visualizer/cif.py
+++ b/openpifpaf/visualizer/cif.py
@@ -20,15 +20,16 @@ class Cif(BaseVisualizer):
         self.keypoints = keypoints
         self.skeleton = skeleton
 
-        self.keypoint_painter = show.KeypointPainter(xy_scale=self.stride)
+        self.keypoint_painter = show.KeypointPainter()  #xy_scale=self.stride)
 
-    def targets(self, field, keypoint_sets):
+    def targets(self, field, *, annotation_dicts):
         assert self.keypoints is not None
         assert self.skeleton is not None
 
         annotations = [
-            Annotation(keypoints=self.keypoints, skeleton=self.skeleton).set(kps, fixed_score=None)
-            for kps in keypoint_sets
+            Annotation(keypoints=self.keypoints, skeleton=self.skeleton).set(
+                ann['keypoints'], fixed_score=None, fixed_bbox=ann['bbox'])
+            for ann in annotation_dicts
         ]
 
         self._confidences(field[0])


### PR DESCRIPTION
This was implemented as an erosion before but removed when introducing nan-based masking. This reintroduces a margin of the size of the active CIF or CAF field.