### PR TITLE
Make resnet50 backbone convertable to tensorRT by using torch2trt

### DIFF
--- a/openpifpaf/network/heads.py
+++ b/openpifpaf/network/heads.py
@@ -233,7 +233,7 @@ class CompositeField3(HeadNetwork):
             # TODO: CoreMLv4 does not like strided slices.
             # Strides are avoided when switching the first and second dim
             # temporarily.
-            x = x.transpose(1, 2)
+            x = torch.transpose(x, 1, 2)
 
             # classification
             classes_x = x[:, 0:self.meta.n_confidences]
@@ -247,7 +247,7 @@ class CompositeField3(HeadNetwork):
             ]
             # regressions x: add index
             index_field = index_field_torch(x.shape[-2:], device=x.device, unsqueeze=(1, 0))
-            regs_x = [reg_x.add(index_field) if do_offset else reg_x
+            regs_x = [torch.add(reg_x, index_field) if do_offset else reg_x
                       for reg_x, do_offset in zip(regs_x, self.meta.vector_offsets)]
 
             # regressions logb
@@ -263,6 +263,6 @@ class CompositeField3(HeadNetwork):
             x = torch.cat([classes_x, *regs_x, regs_logb, scales_x], dim=1)
 
             # TODO: CoreMLv4 problem (see above).
-            x = x.transpose(1, 2)
+            x = torch.transpose(x, 1, 2)
 
         return x


### PR DESCRIPTION
* Change inplace ops by torch.op to compatible with torch2trt converter
* Todo: Implement PixelShuffle Layer for converting PixelShuffle backbone, C++ implementation, deepstream gst plugin for Nvidia edge devices.
