### PR TITLE
Score weights 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .DS_Store
 .vscode
 *.so
+.idea
+openpifpaf/.idea
 
 # Python
 build/
@@ -30,6 +32,7 @@ data-*/
 data_*/
 docs-private/
 data-mscoco
+data/
 *debug.png
 *.pl
 *.pl-*

--- a/openpifpaf/annotation.py
+++ b/openpifpaf/annotation.py
@@ -27,11 +27,11 @@ class Annotation(Base):
         self.frontier_order = []
 
         self.skeleton_m1 = (np.asarray(skeleton) - 1).tolist()
-        if not score_weights:
+        if score_weights is None:
             self.score_weights = np.ones((len(keypoints),))
         else:
             assert len(self.score_weights) == len(keypoints), "wrong number of scores"
-            self.score_weights = np.array(self.score_weights)
+            self.score_weights = np.asarray(self.score_weights)
         if self.suppress_score_index:
             self.score_weights[-1] = 0.0
         self.score_weights /= np.sum(self.score_weights)

--- a/openpifpaf/annotation.py
+++ b/openpifpaf/annotation.py
@@ -10,11 +10,12 @@ class Base:
 
 class Annotation(Base):
     def __init__(self, keypoints, skeleton, sigmas=None, *,
-                 categories=None, suppress_score_index=None):
+                 categories=None, score_weights=None, suppress_score_index=None):
         self.keypoints = keypoints
         self.skeleton = skeleton
         self.sigmas = sigmas
         self.categories = categories
+        self.score_weights = score_weights
         self.suppress_score_index = suppress_score_index
 
         self.category_id = 1
@@ -26,11 +27,14 @@ class Annotation(Base):
         self.frontier_order = []
 
         self.skeleton_m1 = (np.asarray(skeleton) - 1).tolist()
-
-        self.score_weights = np.ones((len(keypoints),))
+        if not score_weights:
+            self.score_weights = np.ones((len(keypoints),))
+        else:
+            assert len(self.score_weights) == len(keypoints), "number of scores does not match keypoint ones"
+            self.score_weights = self.score_weights
         if self.suppress_score_index:
             self.score_weights[-1] = 0.0
-        self.score_weights[:3] = 3.0
+
         self.score_weights /= np.sum(self.score_weights)
 
     @property

--- a/openpifpaf/annotation.py
+++ b/openpifpaf/annotation.py
@@ -29,13 +29,12 @@ class Annotation(Base):
         self.skeleton_m1 = (np.asarray(skeleton) - 1).tolist()
         if not score_weights:
             self.score_weights = np.ones((len(keypoints),))
+            self.score_weights[:3] = 3.0
         else:
-            assert len(self.score_weights) == len(keypoints), \
-                "number of scores does not match keypoint ones"
-            self.score_weights = self.score_weights
+            assert len(self.score_weights) == len(keypoints), "wrong number of scores"
+            self.score_weights = np.array(self.score_weights)
         if self.suppress_score_index:
             self.score_weights[-1] = 0.0
-
         self.score_weights /= np.sum(self.score_weights)
 
     @property

--- a/openpifpaf/annotation.py
+++ b/openpifpaf/annotation.py
@@ -29,7 +29,6 @@ class Annotation(Base):
         self.skeleton_m1 = (np.asarray(skeleton) - 1).tolist()
         if not score_weights:
             self.score_weights = np.ones((len(keypoints),))
-            self.score_weights[:3] = 3.0
         else:
             assert len(self.score_weights) == len(keypoints), "wrong number of scores"
             self.score_weights = np.array(self.score_weights)

--- a/openpifpaf/annotation.py
+++ b/openpifpaf/annotation.py
@@ -30,7 +30,8 @@ class Annotation(Base):
         if not score_weights:
             self.score_weights = np.ones((len(keypoints),))
         else:
-            assert len(self.score_weights) == len(keypoints), "number of scores does not match keypoint ones"
+            assert len(self.score_weights) == len(keypoints), \
+                "number of scores does not match keypoint ones"
             self.score_weights = self.score_weights
         if self.suppress_score_index:
             self.score_weights[-1] = 0.0

--- a/openpifpaf/datasets/cocokp.py
+++ b/openpifpaf/datasets/cocokp.py
@@ -11,6 +11,7 @@ from .constants import (
     COCO_KEYPOINTS,
     COCO_PERSON_SKELETON,
     COCO_PERSON_SIGMAS,
+    COCO_PERSON_SCORE_WEIGHTS,
     COCO_UPRIGHT_POSE,
     DENSER_COCO_PERSON_CONNECTIONS,
     HFLIP,
@@ -58,7 +59,8 @@ class CocoKp(DataModule):
                            keypoints=COCO_KEYPOINTS,
                            sigmas=COCO_PERSON_SIGMAS,
                            pose=COCO_UPRIGHT_POSE,
-                           draw_skeleton=COCO_PERSON_SKELETON)
+                           draw_skeleton=COCO_PERSON_SKELETON,
+                           score_weights=COCO_PERSON_SCORE_WEIGHTS)
         caf = headmeta.Caf('caf', 'cocokp',
                            keypoints=COCO_KEYPOINTS,
                            sigmas=COCO_PERSON_SIGMAS,

--- a/openpifpaf/datasets/constants.py
+++ b/openpifpaf/datasets/constants.py
@@ -146,7 +146,9 @@ COCO_PERSON_SIGMAS = [
     0.089,  # ankles
 ]
 
+
 COCO_PERSON_SCORE_WEIGHTS = [3.0] * 3 + [1.0] * (len(COCO_KEYPOINTS) - 3)
+
 
 COCO_CATEGORIES = [
     'person',

--- a/openpifpaf/datasets/constants.py
+++ b/openpifpaf/datasets/constants.py
@@ -146,6 +146,7 @@ COCO_PERSON_SIGMAS = [
     0.089,  # ankles
 ]
 
+COCO_PERSON_SCORE_WEIGHTS = [3.0] * 3 + [1.0] * (len(COCO_KEYPOINTS) - 3)
 
 COCO_CATEGORIES = [
     'person',
@@ -276,15 +277,21 @@ def draw_skeletons(pose):
     show.KeypointPainter.show_joint_scales = True
     keypoint_painter = show.KeypointPainter(color_connections=True, linewidth=6)
 
-    ann = Annotation(keypoints=COCO_KEYPOINTS, skeleton=COCO_PERSON_SKELETON)
+    ann = Annotation(keypoints=COCO_KEYPOINTS,
+                     skeleton=COCO_PERSON_SKELETON,
+                     score_weights=COCO_PERSON_SCORE_WEIGHTS)
     ann.set(pose, np.array(COCO_PERSON_SIGMAS) * scale)
     draw_ann(ann, filename='docs/skeleton_coco.png', keypoint_painter=keypoint_painter)
 
-    ann = Annotation(keypoints=COCO_KEYPOINTS, skeleton=KINEMATIC_TREE_SKELETON)
+    ann = Annotation(keypoints=COCO_KEYPOINTS,
+                     skeleton=KINEMATIC_TREE_SKELETON,
+                     score_weights=COCO_PERSON_SCORE_WEIGHTS)
     ann.set(pose, np.array(COCO_PERSON_SIGMAS) * scale)
     draw_ann(ann, filename='docs/skeleton_kinematic_tree.png', keypoint_painter=keypoint_painter)
 
-    ann = Annotation(keypoints=COCO_KEYPOINTS, skeleton=DENSER_COCO_PERSON_SKELETON)
+    ann = Annotation(keypoints=COCO_KEYPOINTS,
+                     skeleton=DENSER_COCO_PERSON_SKELETON,
+                     score_weights=COCO_PERSON_SCORE_WEIGHTS)
     ann.set(pose, np.array(COCO_PERSON_SIGMAS) * scale)
     draw_ann(ann, filename='docs/skeleton_dense.png', keypoint_painter=keypoint_painter)
 

--- a/openpifpaf/decoder/cifcaf.py
+++ b/openpifpaf/decoder/cifcaf.py
@@ -80,7 +80,7 @@ class CifCaf(Decoder):
         self.caf_metas = caf_metas
         self.skeleton_m1 = np.asarray(self.caf_metas[0].skeleton) - 1
         self.keypoints = cif_metas[0].keypoints
-        self.scores = cif_metas[0].score_weights
+        self.score_weights = cif_metas[0].score_weights
         self.out_skeleton = caf_metas[0].skeleton
         self.confidence_scales = caf_metas[0].decoder_confidence_scales
 
@@ -189,7 +189,7 @@ class CifCaf(Decoder):
             if occupied.get(f, x, y):
                 continue
 
-            ann = Annotation(self.keypoints, self.out_skeleton).add(f, (x, y, v))
+            ann = Annotation(self.keypoints, self.out_skeleton, score_weights=self.score_weights).add(f, (x, y, v))
             ann.joint_scales[f] = s
             self._grow(ann, caf_scored)
             annotations.append(ann)

--- a/openpifpaf/decoder/cifcaf.py
+++ b/openpifpaf/decoder/cifcaf.py
@@ -189,7 +189,10 @@ class CifCaf(Decoder):
             if occupied.get(f, x, y):
                 continue
 
-            ann = Annotation(self.keypoints, self.out_skeleton, score_weights=self.score_weights).add(f, (x, y, v))
+            ann = Annotation(self.keypoints,
+                             self.out_skeleton,
+                             score_weights=self.score_weights
+                             ).add(f, (x, y, v))
             ann.joint_scales[f] = s
             self._grow(ann, caf_scored)
             annotations.append(ann)

--- a/openpifpaf/decoder/cifcaf.py
+++ b/openpifpaf/decoder/cifcaf.py
@@ -80,6 +80,7 @@ class CifCaf(Decoder):
         self.caf_metas = caf_metas
         self.skeleton_m1 = np.asarray(self.caf_metas[0].skeleton) - 1
         self.keypoints = cif_metas[0].keypoints
+        self.scores = cif_metas[0].score_weights
         self.out_skeleton = caf_metas[0].skeleton
         self.confidence_scales = caf_metas[0].decoder_confidence_scales
 

--- a/openpifpaf/headmeta.py
+++ b/openpifpaf/headmeta.py
@@ -34,6 +34,7 @@ class Cif(Base):
     sigmas: List[float]
     pose: Any
     draw_skeleton: List[Tuple[int, int]] = None
+    score_weights: List[float] = None
 
     n_confidences: ClassVar[int] = 1
     n_vectors: ClassVar[int] = 1

--- a/openpifpaf/network/nets.py
+++ b/openpifpaf/network/nets.py
@@ -3,6 +3,7 @@ import torch
 
 from . import heads
 from .. import datasets
+from ..datasets.constants import COCO_PERSON_SCORE_WEIGHTS
 
 LOG = logging.getLogger(__name__)
 
@@ -188,7 +189,8 @@ def model_migration(net_cpu):
             hn.meta.base_stride = net_cpu.base_net.stride
         if hn.meta.head_index is None:
             hn.meta.head_index = hn_i
-
+        if hn.meta.name == 'cif' and hn.meta.score_weights is None:
+            hn.meta.score_weights = COCO_PERSON_SCORE_WEIGHTS
     for mm in MODEL_MIGRATION:
         mm(net_cpu)
 

--- a/openpifpaf/network/nets.py
+++ b/openpifpaf/network/nets.py
@@ -3,7 +3,6 @@ import torch
 
 from . import heads
 from .. import datasets
-from ..datasets.constants import COCO_PERSON_SCORE_WEIGHTS
 
 LOG = logging.getLogger(__name__)
 
@@ -189,7 +188,7 @@ def model_migration(net_cpu):
             hn.meta.base_stride = net_cpu.base_net.stride
         if hn.meta.head_index is None:
             hn.meta.head_index = hn_i
-        if hn.meta.name == 'cif' and hn.meta.score_weights is None:
+        if hn.meta.name == 'cif' and 'score_weights' not in vars(hn.meta):
             hn.meta.score_weights = [3.0] * 3 + [1.0] * (hn.meta.n_fields - 3)
     for mm in MODEL_MIGRATION:
         mm(net_cpu)

--- a/openpifpaf/network/nets.py
+++ b/openpifpaf/network/nets.py
@@ -190,7 +190,7 @@ def model_migration(net_cpu):
         if hn.meta.head_index is None:
             hn.meta.head_index = hn_i
         if hn.meta.name == 'cif' and hn.meta.score_weights is None:
-            hn.meta.score_weights = COCO_PERSON_SCORE_WEIGHTS
+            hn.meta.score_weights = [3.0] * 3 + [1.0] * (hn.meta.n_fields - 3)
     for mm in MODEL_MIGRATION:
         mm(net_cpu)
 

--- a/openpifpaf/show/painters.py
+++ b/openpifpaf/show/painters.py
@@ -19,11 +19,11 @@ class AnnotationPainter:
     def __init__(self, *,
                  xy_scale=1.0,
                  keypoint_painter=None,
-                 crowd_painer=None,
+                 crowd_painter=None,
                  detection_painter=None):
         self.painters = {
             'Annotation': keypoint_painter or KeypointPainter(xy_scale=xy_scale),
-            'AnnotationCrowd': crowd_painer or CrowdPainter(xy_scale=xy_scale),
+            'AnnotationCrowd': crowd_painter or CrowdPainter(xy_scale=xy_scale),
             'AnnotationDet': detection_painter or DetectionPainter(xy_scale=xy_scale),
         }
 

--- a/openpifpaf/visualizer/cif.py
+++ b/openpifpaf/visualizer/cif.py
@@ -35,6 +35,7 @@ class Cif(Base):
                 keypoints=self.meta.keypoints,
                 skeleton=self.meta.draw_skeleton,
                 sigmas=self.meta.sigmas,
+                score_weights=self.meta.score_weights
             ).set(
                 ann['keypoints'], fixed_score='', fixed_bbox=ann['bbox'])
             for ann in annotation_dicts


### PR DESCRIPTION
This makes joint score weights customisable, depending on the dataset.
* Scores of old models do not change (migration function updated)
* All new models will now contain score_weights in their Cif meta.
    * The default is all ones if not specified in Cif meta
    * Training on coco_kp dataset will assign the same weighting as before, but this is now customisable
  
