### PR TITLE
Preprocess inverse plugin

### DIFF
--- a/openpifpaf/__init__.py
+++ b/openpifpaf/__init__.py
@@ -18,3 +18,4 @@ from .datasets import DATAMODULES
 from .decoder import DECODERS
 from .network.factory import BASE_FACTORIES, BASE_TYPES, HEAD_FACTORIES, HEAD_TYPES
 from .network.nets import MODEL_MIGRATION
+from .transforms.preprocess import PREPROCESS_INVERSE


### PR DESCRIPTION
When using a new annotation container, a preprocess inverse function is needed since it is called by predict.py. This provides a plugin support for Preprocess.annotation_inverse.