### PR TITLE
shuffle val loader

### DIFF
--- a/openpifpaf/plugins/cifar10/datamodule.py
+++ b/openpifpaf/plugins/cifar10/datamodule.py
@@ -80,7 +80,7 @@ class Cifar10(openpifpaf.datasets.DataModule):
             preprocess=self._preprocess(),
         )
         return torch.utils.data.DataLoader(
-            val_data, batch_size=self.batch_size, shuffle=False,
+            val_data, batch_size=self.batch_size, shuffle=not self.debug,
             pin_memory=self.pin_memory, num_workers=self.loader_workers, drop_last=True,
             collate_fn=openpifpaf.datasets.collate_images_targets_meta)
 

--- a/openpifpaf/plugins/coco/cocodet.py
+++ b/openpifpaf/plugins/coco/cocodet.py
@@ -168,7 +168,7 @@ class CocoDet(openpifpaf.datasets.DataModule):
             category_ids=[],
         )
         return torch.utils.data.DataLoader(
-            val_data, batch_size=self.batch_size, shuffle=False,
+            val_data, batch_size=self.batch_size, shuffle=not self.debug and self.augmentation,
             pin_memory=self.pin_memory, num_workers=self.loader_workers, drop_last=True,
             collate_fn=openpifpaf.datasets.collate_images_targets_meta)
 

--- a/openpifpaf/plugins/coco/cocokp.py
+++ b/openpifpaf/plugins/coco/cocokp.py
@@ -243,7 +243,7 @@ class CocoKp(openpifpaf.datasets.DataModule):
             category_ids=[1],
         )
         return torch.utils.data.DataLoader(
-            val_data, batch_size=self.batch_size, shuffle=False,
+            val_data, batch_size=self.batch_size, shuffle=not self.debug and self.augmentation,
             pin_memory=self.pin_memory, num_workers=self.loader_workers, drop_last=True,
             collate_fn=openpifpaf.datasets.collate_images_targets_meta)
 


### PR DESCRIPTION
Shuffling the validation data loader is important for datasets that are not random.

For video datasets or datasets that have certain samples before others, it is important to have shuffling enabled. Without shuffling, the distribution within a batch is different while BatchNorm still runs with the statistics of the current batch only. During eval, BatchNorm is fixed and this does not matter anymore.

CC @george-adaimi @bertoni9 