### PR TITLE
use OpenCV for fast rescaling when available

### DIFF
--- a/tests/test_image_scale.py
+++ b/tests/test_image_scale.py
@@ -1,6 +1,6 @@
-import numpy as np
 import time
 
+import numpy as np
 import PIL.Image
 import pytest
 import scipy.ndimage

--- a/tests/test_image_scale.py
+++ b/tests/test_image_scale.py
@@ -1,7 +1,14 @@
 import numpy as np
+import time
+
 import PIL.Image
 import pytest
 import scipy.ndimage
+
+try:
+    import cv2
+except ImportError:
+    cv2 = None
 
 
 @pytest.mark.parametrize('resample', [PIL.Image.BILINEAR, PIL.Image.BICUBIC])
@@ -29,3 +36,21 @@ def test_scipy_zoom(order):
 
     print(d_out)
     assert np.all(d_in == d_out[0, ::2])
+
+
+def test_opencv_faster_than_pil():
+    image = PIL.Image.new('RGB', (640, 640))
+
+    pil_start = time.perf_counter()
+    for _ in range(5):
+        image.resize((500, 500))
+    pil_time = time.perf_counter() - pil_start
+
+    cv_start = time.perf_counter()
+    for _ in range(5):
+        im_np = np.asarray(image)
+        PIL.Image.fromarray(cv2.resize(im_np, (500, 500)))
+    cv_time = time.perf_counter() - cv_start
+
+    print(f'pil: {pil_time}, cv: {cv_time}')
+    assert cv_time < 0.5 * pil_time


### PR DESCRIPTION
When requesting fast rescaling and OpenCV is available, use it. This only affects `openpifpaf.predict` and `openpifpaf.video`. Fast rescaling is not requested during training and evaluation.

This PR also contains a test to make sure that the assumption that OpenCV is faster than Pillow holds in the future.

Fixes #360 .