### PR TITLE
use LRScheduler.last_epoch

### DIFF
--- a/openpifpaf/network/trainer.py
+++ b/openpifpaf/network/trainer.py
@@ -6,7 +6,6 @@ import hashlib
 import logging
 import shutil
 import time
-import warnings
 
 import torch
 

--- a/openpifpaf/network/trainer.py
+++ b/openpifpaf/network/trainer.py
@@ -153,10 +153,7 @@ class Trainer():
                             ''.format(start_epoch, self.epochs))
 
         if self.lr_scheduler is not None:
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
-                for _ in range(start_epoch * len(train_scenes)):
-                    self.lr_scheduler.step()
+            assert self.lr_scheduler.last_epoch == start_epoch * len(train_scenes)
 
         for epoch in range(start_epoch, self.epochs):
             if epoch == 0:

--- a/openpifpaf/train.py
+++ b/openpifpaf/train.py
@@ -177,7 +177,7 @@ def main():
 
     optimizer = optimize.factory_optimizer(
         args, list(net.parameters()) + list(loss.parameters()))
-    lr_scheduler = optimize.factory_lrscheduler(args, optimizer, len(train_loader))
+    lr_scheduler = optimize.factory_lrscheduler(args, optimizer, len(train_loader), last_epoch=start_epoch)
     trainer = network.Trainer(
         net, loss, optimizer, args.output,
         checkpoint_shell=checkpoint_shell,

--- a/openpifpaf/train.py
+++ b/openpifpaf/train.py
@@ -177,7 +177,8 @@ def main():
 
     optimizer = optimize.factory_optimizer(
         args, list(net.parameters()) + list(loss.parameters()))
-    lr_scheduler = optimize.factory_lrscheduler(args, optimizer, len(train_loader), last_epoch=start_epoch)
+    lr_scheduler = optimize.factory_lrscheduler(
+        args, optimizer, len(train_loader), last_epoch=start_epoch)
     trainer = network.Trainer(
         net, loss, optimizer, args.output,
         checkpoint_shell=checkpoint_shell,


### PR DESCRIPTION
When loading a checkpoint at epoch 250 for training with batch_size 2, the initialization of the LR scheduler took extremely long as it went through over seven million steps one by one.